### PR TITLE
가상환경이 아닌 실제 PC에서 소수점 계산 중 GP exception 발생하는 문제 해결

### DIFF
--- a/02.Kernel64/Source/Task.c
+++ b/02.Kernel64/Source/Task.c
@@ -323,6 +323,7 @@ void kInitializeScheduler( void )
     pstTask->qwMemorySize = 0x500000;
     pstTask->pvStackAddress = ( void* ) 0x600000;
     pstTask->qwStackSize = 0x100000;
+    pstTask->bFPUUsed = FALSE;
     
     // 프로세서 사용률을 계산하는데 사용하는 자료구조 초기화
     gs_vstScheduler[ bCurrentAPICID ].qwSpendProcessorTimeInIdleTask = 0;


### PR DESCRIPTION
task 생성때 bFPUUsed 변수가 0이 아닌 임의의 숫자를 가지고 있었음.
이로 인해 FPU 관련 코드가 잘못된 코드를 실행하고 GP exception이 발생했음.