### PR TITLE
kernel process의 stChildThreadList를 초기화하기

### DIFF
--- a/02.Kernel64/Source/Task.c
+++ b/02.Kernel64/Source/Task.c
@@ -324,6 +324,9 @@ void kInitializeScheduler( void )
     pstTask->pvStackAddress = ( void* ) 0x600000;
     pstTask->qwStackSize = 0x100000;
     
+    // 프로세스 스레드 리스트 초기화
+    kInitializeList(&(pstTask->stChildThreadList));
+    
     // 프로세서 사용률을 계산하는데 사용하는 자료구조 초기화
     gs_vstScheduler[ bCurrentAPICID ].qwSpendProcessorTimeInIdleTask = 0;
     gs_vstScheduler[ bCurrentAPICID ].qwProcessorLoad = 0;


### PR DESCRIPTION
kernel process의 stChildThreadList를 초기화 하지 않음으로써 실제 컴퓨터에서 구동이 안되는 문제해결
  - 커널에 kIdleTask라는 이름의 thread가 커널 프로세스의 쓰레드 리스트에 정상적으로 들어가지 않았었음
  - kIdleTask의 qwID를 부모 process (kernel process)의 list에 연결할 떄 존재하지 않는 메모리 참조가 일어나면서 general protection exception이 발생했음